### PR TITLE
Add travis support for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 before_install:
-   - sudo apt-get install libgsl0-dev
+   - sudo libzmq3-dev libjansson-dev python-sympy python-jinja2 python-dateutil libgsl0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 before_install:
-   - sudo libzmq3-dev libjansson-dev python-sympy python-jinja2 python-dateutil libgsl0-dev
+   - sudo apt-get install python-software-properties python g++ make build-essential
+   - sudo apt-get install libzmq3-dev libjansson-dev python-sympy python-jinja2 python-dateutil libgsl0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 before_install:
-   - apt-get install libgsl0-dev
+   - sudo apt-get install libgsl0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 before_install:
-   - sudo apt-get install python-software-properties python g++ make build-essential
+   - sudo apt-get install python-software-properties make build-essential
    - sudo apt-get install libzmq3-dev libjansson-dev python-sympy python-jinja2 python-dateutil libgsl0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+before_install:
+   - apt-get install libgsl0-dev

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 S|S|M
 =====
 
+[![Build Status](https://travis-ci.org/SergeStinckwich/ssm.png?branch=master)](https://travis-ci.org/SergeStinckwich/ssm)
+
 Inference for time series analysis with *S*tate *S*pace *M*odels, like
 playing with duplo blocks.
 


### PR DESCRIPTION
I add travis support for SSM in order to use continuous integration for the project.
The project is green at the moment, look here: https://travis-ci.org/SergeStinckwich/ssm
The build result is displayed on the README file.
You have to create your own travis account (this is free) in order to use CI.
